### PR TITLE
fix: correct SessionStart hook JSON structure for Claude Code Web

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,13 @@
   "hooks": {
     "SessionStart": [
       {
-        "type": "command",
-        "command": "./setup-nix-web.sh"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./setup-nix-web.sh",
+            "timeout": 300
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
The hook wasn't firing because the JSON structure was wrong.
SessionStart array elements must be matcher objects containing a
`hooks` array, not direct hook objects. Also set timeout to 300s
to accommodate Nix + Home Manager bootstrap time.

Ref: https://zenn.dev/oikon/articles/claude-code-web-gh-cli

https://claude.ai/code/session_0173f4JEzQCb1jEJsZUTzfac