### PR TITLE
feat: bootstrap apm vendoring framework for third-party skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,11 @@ pre-commit run --all-files
 
 # Update flake inputs
 nix flake update
+
+# 3rd-party agent skill 管理（apm 経由）
+cd config/agents/vendored
+apm install <owner>/<repo>#<sha> -t claude   # SHA pin 必須（drift 防止）
+apm audit                                     # 隠しUnicode検出
 ```
 
 ## Architecture
@@ -34,6 +39,7 @@ nix flake update
   - `shell.nix` - Zsh config with Oh My Zsh, shell aliases, and `initExtra` scripts (mise, gcloud, Java, etc.)
   - `git.nix` - Git の設定（gitignore 等）。
   - `agent-skills.nix` - エージェント関連の統一管理モジュール。[agent-skills-nix](https://github.com/Kyure-A/agent-skills-nix) によるスキルデプロイ（`~/.claude/skills/`, `~/.agents/skills/`）に加え、Codex 互換パス `~/.codex/skills/` の維持、エージェント定義・コマンド・ルール・スクリプトのデプロイ、Claude Code グローバル設定（`~/.claude/settings.json`）、Codex CLI ルール（`~/.codex/rules/`）も管理。
+  - `apm.nix` - [Microsoft APM](https://github.com/microsoft/apm) CLI を release tarball から fetchurl で取得して Nix 管理化。3rd-party agent skill の宣言的・lock 付き管理に使用。PyInstaller bundle のため `dontStrip` / `dontFixup` / `dontPatchELF` を全て無効化。
 - `config/agents/skills/` - Claude Code / OpenAI Codex 共通のスキル定義。agent-skills-nix 経由でデプロイ。Lakeview ダッシュボード設計者用の `steering-lakeview-handoff` 等を含む。
 - `config/agents/rules/` - Claude Code のグローバルルール。`~/.claude/rules/` にデプロイされ、起動時に常に読み込まれる。スキルの発動トリガー条件を定義。
 - `config/agents/definitions/` - エージェント定義。`~/.claude/agents/` にデプロイ。開発ワークフロー用エージェント（planner, architect, code-reviewer, tdd-guide, security-reviewer, doc-updater, python-reviewer, terraform-reviewer）と検索用エージェント（steering-research, doc-search）を含む。
@@ -41,6 +47,7 @@ nix flake update
 - `config/agents/skills/orchestrate/` - Claude Code の `/orchestrate` と同じ運用意図を Codex でも使えるようにした共通オーケストレーションスキル。`~/.agents/skills/` にデプロイされ、移行期間は `~/.codex/skills/` からも参照できる。
 - `config/agents/scripts/` - Claude Code 用のヘルパースクリプト。`~/.claude/scripts/` にデプロイ。statusline 表示用スクリプト・`sync-to-genie.sh`（Databricks Genie Code 同期）等を含む。
 - `config/genie/skills/` - Databricks Genie Code 用スキル定義。`agent-skills.nix` で `~/.claude/genie-skills/` にデプロイされ、`sync-to-genie.sh --init-all` で Databricks Workspace の `.assistant/skills/` に push される。Lakeview ウィジェット実装者用の `steering-lakeview-handoff`（Claude Code 側スキルと対称）と `lakeview-pitfalls`（pitfall カタログ）を含む。
+- `config/agents/vendored/` - 3rd-party agent skill の vendor 先。`apm.yml` で依存宣言、`apm.lock.yaml` で SHA pin、`apm install` 実行で `.claude/skills/` 配下に integrated output を生成。実験段階では integrated output を gitignore で除外（vendor-commit に切り替える場合は `.gitignore` から `.claude/` を削除）。
 - `.zshrc` - Legacy standalone zsh config (being migrated into `modules/shell.nix`).
 
 ## Nix Conventions
@@ -74,3 +81,40 @@ nix flake update
 4. `sync-to-genie.sh --init-all` で Databricks Workspace `.assistant/skills/` に push
 
 **重要**: `sync-to-genie.sh --init-all` は **SKILL.md のみ** をアップロードする。`references/` や `templates/` サブディレクトリは Databricks workspace に転送されないため、Genie Code が参照する必要のある内容は SKILL.md にインライン化する必要がある。
+
+## Third-Party Agent Skills (apm)
+
+3rd-party agent skill（`anthropics/skills`、`mizchi/skills` 等）は **apm 経由で `config/agents/vendored/` に vendor** する。自作スキルは従来どおり `config/agents/skills/` に置き、`agent-skills-nix` でデプロイする（**自作スキルを別 repo に切り出さない方針**）。
+
+**apm 互換性の判断**:
+
+| repo の構造                                                             | apm | gh skill | 備考                                                        |
+| ----------------------------------------------------------------------- | --- | -------- | ----------------------------------------------------------- |
+| repo root に `apm.yml` または `.apm/` がある（例: `anthropics/skills`） | ✅  | ✅       | apm を使う                                                  |
+| repo root 直下に `<name>/SKILL.md` が並ぶ（例: `mizchi/skills`）        | ❌  | ✅       | apm 不可。`gh skill install <repo> <name> -t claude` を使う |
+| 単独 SKILL.md（repo がそのまま 1 skill）                                | ✅  | ✅       | どちらでも可                                                |
+
+**apm 経由のワークフロー**:
+
+```bash
+cd config/agents/vendored
+
+# 新規追加（必ず SHA pin する。warning が出たら未 pin）
+apm install <owner>/<repo>#<commit-sha> -t claude
+
+# audit で隠しUnicode検出（commit 前必須）
+apm audit
+
+# 出力構造: vendored/.claude/skills/<skill-name>/
+ls .claude/skills/
+
+# apm.yml + apm.lock.yaml を必ず commit
+git add apm.yml apm.lock.yaml
+```
+
+**重要事項**:
+
+- **SHA pin 必須**: `<repo>#main` ではドリフトする。`apm.lock.yaml` の `resolved_commit` から取得して pin する
+- **`apm_modules/` は gitignore 済**（apm が自動生成）。raw download は git 管理外
+- **`apm audit` で `info-level` 以上の検出が出たら commit 前に確認**（プロンプトインジェクション対策）
+- **frontmatter に source tracking なし**: `gh skill` と異なり、出所追跡は `apm.lock.yaml` のみ。lock 必ず commit すること

--- a/config/agents/vendored/.gitignore
+++ b/config/agents/vendored/.gitignore
@@ -1,0 +1,8 @@
+
+# APM dependencies
+apm_modules/
+
+# 実験段階: integrated output はまだ commit せず、framework のみ管理。
+# 本番統合（agent-skills.nix 2-source 化）時に vendor-commit する場合は
+# 以下の行を削除する。
+.claude/

--- a/config/agents/vendored/apm.lock.yaml
+++ b/config/agents/vendored/apm.lock.yaml
@@ -1,0 +1,28 @@
+lockfile_version: "1"
+generated_at: "2026-04-25T14:23:31.888177+00:00"
+apm_version: 0.9.2
+dependencies:
+  - repo_url: anthropics/skills
+    host: github.com
+    resolved_commit: 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9
+    resolved_ref: 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9
+    package_type: apm_package
+    deployed_files:
+      - .claude/skills/algorithmic-art
+      - .claude/skills/brand-guidelines
+      - .claude/skills/canvas-design
+      - .claude/skills/claude-api
+      - .claude/skills/doc-coauthoring
+      - .claude/skills/docx
+      - .claude/skills/frontend-design
+      - .claude/skills/internal-comms
+      - .claude/skills/mcp-builder
+      - .claude/skills/pdf
+      - .claude/skills/pptx
+      - .claude/skills/skill-creator
+      - .claude/skills/slack-gif-creator
+      - .claude/skills/theme-factory
+      - .claude/skills/web-artifacts-builder
+      - .claude/skills/webapp-testing
+      - .claude/skills/xlsx
+    content_hash: sha256:0298046fc0f4dc458e46a275d981178f506f1f53a32eaa351bfce7433478f578

--- a/config/agents/vendored/apm.yml
+++ b/config/agents/vendored/apm.yml
@@ -1,0 +1,9 @@
+name: vendored
+version: 1.0.0
+description: APM project for vendored
+author: kumewata
+dependencies:
+  apm:
+    - anthropics/skills#5128e1865d670f5d6c9cef000e6dfc4e951fb5b9
+  mcp: []
+scripts: {}


### PR DESCRIPTION
## Summary

- `config/agents/vendored/` を 3rd-party agent skill の vendor 先として整備（apm.yml + apm.lock.yaml + .gitignore のみ commit、`apm_modules/` と `.claude/` は gitignore）
- `CLAUDE.md` に apm-vs-gh-skill 互換性マトリクスとワークフローを追記
- `anthropics/skills` を SHA pin（`5128e186`）した worked example を `apm.yml` に同梱

## なぜこの構成か

- **apm 互換性は repo 構造依存**: `mizchi/skills` のように subdirectory に SKILL.md が並ぶ repo は apm install で `Not a valid APM package` で落ちる。\`apm.yml\` か `.apm/` を持つ repo（例: `anthropics/skills`）のみ apm が使える
- **整合性のため SHA pin 必須**: 未 pin だと apm install が drift warning を出す。`apm.lock.yaml` の `resolved_commit` から取った SHA を `<owner>/<repo>#<sha>` 形式で apm.yml に書く
- **integrated output は実験段階で gitignore**: `agent-skills.nix` の 2-source 化を別 PR で詰める前に、framework だけを commit する。本番統合時に `.claude/` を gitignore から外すかは別途判断

## Test plan

- [x] `apm install anthropics/skills#5128e186 -t claude` が成功し `.claude/skills/` 配下に 17 skill 展開
- [x] `apm audit` が動作（45 info-level findings 検出を確認）
- [x] `apm.lock.yaml` に `resolved_commit` と `content_hash` が記録されること
- [x] `apm_modules/` と `.claude/` が gitignore で除外されること
- [x] `pre-commit run --all-files` (treefmt) が pass

## Out of scope（次の PR）

- `modules/agent-skills.nix` の 2-source 化（vendored を実 deploy 対象に追加）
- vendored output を vendor-commit するか、毎回 apm install するかの最終判断
- mizchi/skills 等 apm 非互換 repo を gh skill で扱う運用ドキュメント整備

🤖 Generated with [Claude Code](https://claude.com/claude-code)